### PR TITLE
Refactor changelog

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,2 +1,0 @@
-2016-02-15 Release 0.1.0
-- Initial Github commit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Fix middleManager node
+- Fix variable contains an uppercase letter puppet-lint warnings which means
+  renaming parameter `druid::pivot::source_list_refresh_onLoad` to
+  `druid::pivot::source_list_refresh_onload`
 
 ## [1.0.0] - 2016-03-07
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## [Unreleased]
+### Added
+- Add extensions_dir to be compatible with Imply 1.2.x
+
+### Changed
+- Move the changelog to markdown and start using semver
+- Change bard to pivot
+- Default imply version changed from 1.1.0 to 1.2.1
+- Change name of pivot config file from `pivot_config.yaml` to `config.yaml`
+
+### Fixed
+- Fix middleManager node
+
+## [1.0.0] - 2016-03-07
+### Changed
+- Better service notifications
+- Default imply version changed from 1.0.0 to 1.1.0
+
+## [0.1.0] - 2016-02-15
+### Added
+- Initial Github commit

--- a/README.markdown
+++ b/README.markdown
@@ -367,7 +367,7 @@ Check for new dataSources periodically. Set to 0 to disable background introspec
 
 Default : 0
 
-#####  `source_list_refresh_onLoad`
+#####  `source_list_refresh_onload`
 
 Checks for new dataSources every time Pivot is loaded
 

--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,6 @@ end
 
 PuppetLint.configuration.relative = true
 PuppetLint.configuration.send("disable_80chars")
-PuppetLint.configuration.log_format = "%{path}:%{linenumber}:%{check}:%{KIND}:%{message}"
 PuppetLint.configuration.fail_on_warnings = true
 
 # Forsake support for Puppet 2.6.2 for the benefit of cleaner code.

--- a/manifests/pivot.pp
+++ b/manifests/pivot.pp
@@ -17,7 +17,7 @@ class druid::pivot (
   $max_workers                  = 0,
   $use_segment_metadata         = false,
   $source_list_refresh_interval = 0,
-  $source_list_refresh_onLoad   = false,
+  $source_list_refresh_onload   = false,
   $install_nodejs               = false,
   $nodejs_version               = 'latest',
 ){
@@ -37,7 +37,7 @@ class druid::pivot (
     $enable_stdout_log,
     $enable_file_log,
     $use_segment_metadata,
-    $source_list_refresh_onLoad,
+    $source_list_refresh_onload,
     $install_nodejs
   )
 

--- a/templates/pivot_config.yaml.erb
+++ b/templates/pivot_config.yaml.erb
@@ -30,4 +30,4 @@ sourceListRefreshInterval: <%= scope.lookupvar("druid::pivot::source_list_refres
 
 # Foreground introspection
 # Checks for new dataSources every time Pivot is loaded (default: false)
-sourceListRefreshOnLoad: <%= scope.lookupvar("druid::pivot::source_list_refresh_onLoad") %>
+sourceListRefreshOnLoad: <%= scope.lookupvar("druid::pivot::source_list_refresh_onload") %>


### PR DESCRIPTION
Switching the changelog to the new format:
The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project now adheres to [Semantic Versioning](http://semver.org/).