### PR TITLE
Puppet archive version 1.3.0 is the last one compatible with puppet 3.x

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,7 +1,9 @@
 fixtures:
   repositories:
     stdlib: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
-    archive: "git://github.com/voxpupuli/puppet-archive.git"
+    archive:
+      repo: "git://github.com/voxpupuli/puppet-archive.git"
+      ref:  "v1.3.0"
     apt: "git://github.com/puppetlabs/puppetlabs-apt.git"
     java: "git://github.com/puppetlabs/puppetlabs-java"
   symlinks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- addec the management of the license for druid-pivot
+
+### Changed
+- Puppet archive version 1.3.0 is the last one compatible with puppet 3.x and
+  the last one compatible with this module for now. Changing the `.fixtures.yml`
+  to reflect that.
+
 
 ## [1.0.1] - 2017-01-31
 ### Fixed

--- a/spec/classes/druid_pivot_spec.rb
+++ b/spec/classes/druid_pivot_spec.rb
@@ -13,6 +13,7 @@ describe 'druid::pivot' do
           puppetversion: Puppet.version
         }
       end
+
       describe "druid class without any parameters on #{osfamily}" do
         let(:params) { {} }
 
@@ -30,6 +31,7 @@ describe 'druid::pivot' do
 
       describe 'with Nodejs with the APT source' do
         let(:params) { { install_nodejs: true } }
+
         it { is_expected.to contain_package('nodejs').with_ensure('latest') }
         it { is_expected.to contain_apt__source('apt-node_4.x') }
       end

--- a/spec/classes/druid_spec.rb
+++ b/spec/classes/druid_spec.rb
@@ -13,6 +13,7 @@ describe 'druid' do
           puppetversion: Puppet.version
         }
       end
+
       describe "druid class without any parameters on #{osfamily}" do
         let(:params) { {} }
 

--- a/spec/defines/druid_node_spec.rb
+++ b/spec/defines/druid_node_spec.rb
@@ -28,6 +28,7 @@ require 'spec_helper'
           java_opts: ['-server', '-Xms10g', '-Xmx10g']
         }
       end
+
       it { is_expected.to contain_class('druid') }
       # it { is_expected.to contain_druid__node(node) }
 


### PR DESCRIPTION
Puppet archive version 1.3.0 is the last one compatible with puppet 3.x and the last one compatible with this module for now. Changing the `.fixtures.yml` to reflect that.