### PR TITLE
Fix puppet lint & tests dependencies

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -4,7 +4,9 @@ fixtures:
     archive:
       repo: "git://github.com/voxpupuli/puppet-archive.git"
       ref:  "v1.3.0"
-    apt: "git://github.com/puppetlabs/puppetlabs-apt.git"
+    apt:
+      repo: "git://github.com/puppetlabs/puppetlabs-apt.git"
+      ref: "2.4.0"
     java: "git://github.com/puppetlabs/puppetlabs-java"
   symlinks:
     druid: "#{source_dir}"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,9 @@ require: rubocop-rspec
 AllCops:
   Include:
     - ./**/*.rb
+    - '**/Gemfile'
+    - '**/Guardfile'
+    - '**/Rakefile'
   Exclude:
     - files/**/*
     - vendor/**/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Puppet archive version 1.3.0 is the last one compatible with puppet 3.x and
   the last one compatible with this module for now. Changing the `.fixtures.yml`
   to reflect that.
+- Same for puppetlabs-apt dependency
+- Fix puppet-lint warnings
 
 
 ## [1.0.1] - 2017-01-31

--- a/Gemfile
+++ b/Gemfile
@@ -8,9 +8,9 @@ group :test do
   gem 'rspec-core', '< 3.2.0' if RUBY_VERSION < '1.9'
   gem 'rspec-puppet'
   gem 'rspec-puppet-facts'
-  gem 'rubocop-rspec', :require => false if RUBY_VERSION >= '2.3.0'
+  gem 'rubocop-rspec', require: false if RUBY_VERSION >= '2.3.0'
   gem 'simplecov', '>= 0.11.0'
-  gem 'simplecov-console', if RUBY_VERSION < '2.0.0' then '< 0.4.0' end
+  gem 'simplecov-console'
 
   gem 'puppet-lint-absolute_classname-check'
   gem 'puppet-lint-classes_and_types_beginning_with_digits-check'

--- a/Guardfile
+++ b/Guardfile
@@ -1,5 +1,5 @@
 notification :off
 
-guard 'rake', :task => 'test' do
+guard 'rake', task: 'test' do
   watch(%r{^manifests\/(.+)\.pp$})
 end

--- a/Rakefile
+++ b/Rakefile
@@ -18,14 +18,15 @@ end
 begin
   require 'rubocop/rake_task'
   RuboCop::RakeTask.new
-rescue LoadError
+rescue LoadError => e
+  puts "INFO: ignoring rubocop tasks as not installed #{e.message}"
 end
 
 exclude_paths = [
-  "bundle/**/*",
-  "pkg/**/*",
-  "vendor/**/*",
-  "spec/**/*",
+  'bundle/**/*',
+  'pkg/**/*',
+  'vendor/**/*',
+  'spec/**/*'
 ]
 
 # Coverage from puppetlabs-spec-helper requires rcov which
@@ -46,20 +47,15 @@ end
 
 PuppetSyntax.exclude_paths = exclude_paths
 
-desc "Run acceptance tests"
+desc 'Run acceptance tests'
 RSpec::Core::RakeTask.new(:acceptance) do |t|
   t.pattern = 'spec/acceptance'
 end
 
-desc "Populate CONTRIBUTORS file"
+desc 'Populate CONTRIBUTORS file'
 task :contributors do
-  system("git log --format='%aN' | sort -u > CONTRIBUTORS")
+  system('git log --format=\'%aN\' | sort -u > CONTRIBUTORS')
 end
 
-desc "Run syntax, lint, and spec tests."
-task :test => [
-  :metadata_lint,
-  :syntax,
-  :lint,
-  :spec,
-]
+desc 'Run syntax, lint, and spec tests.'
+task test: %w[metadata_lint syntax lint spec]

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -57,8 +57,8 @@ class druid (
   contain '::druid::install'
   contain '::druid::config'
 
-Class['::druid::install'] ->
-Class['::druid::config']
+Class['::druid::install'] -> Class['::druid::config']
+
 if $logstash_server {
   class {'::druid::logstash':
     require => Class['::druid::install'],

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -33,8 +33,7 @@ class druid::install {
       source       => "http://static.imply.io/release/imply-${druid::imply_version}.tar.gz",
       extract      => true,
       extract_path => '/opt',
-    } ->
-    file { "${druid::install_dir}/${druid::install_link}":
+      } -> file { "${druid::install_dir}/${druid::install_link}":
       ensure => 'link',
       target => "${druid::install_dir}/imply-${druid::imply_version}",
     }

--- a/manifests/pivot.pp
+++ b/manifests/pivot.pp
@@ -42,10 +42,10 @@ class druid::pivot (
     $install_nodejs
   )
 
-  Class['::druid'] ->
-  class { '::druid::pivot::install': } ->
-  class { '::druid::pivot::config':  } ~>
-  class { '::druid::pivot::service': } ->
-  Class['::druid::pivot']
+  Class['::druid']
+  -> class { '::druid::pivot::install': }
+  -> class { '::druid::pivot::config':  }
+  ~> class { '::druid::pivot::service': }
+  -> Class['::druid::pivot']
 
 }

--- a/spec/defines/druid_node_spec.rb
+++ b/spec/defines/druid_node_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-%w(broker coordinator historical middle_manager overlord).each do |node|
+%w[broker coordinator historical middle_manager overlord].each do |node|
   describe 'druid::node', type: :define do
     let(:facts) do
       {


### PR DESCRIPTION
Fixes warnings related to one of the latest additions in puppet-lint: https://docs.puppet.com/puppet/latest/style_guide.html#chaining-arrow-syntax

Puppetlabs-apt also dropped puppet 3.x dependency in 3.0 so add the corresponding ref in the fixtures.

FYI @br0ch0n @ynnt @alekseymykhailov 
Thx!