### PR TITLE
Feature/imply2.4.1 upgrade

### DIFF
--- a/manifests/pivot.pp
+++ b/manifests/pivot.pp
@@ -10,6 +10,7 @@
 class druid::pivot (
   $home_dir                     = '/opt/imply/dist/imply-ui',
   $config_dir                   = '/opt/imply/conf/pivot',
+  $state_file                   = '/mnt/pivot/state',
   $port                         = 9095,
   $broker_host                  = 'localhost:8082',
   $enable_stdout_log            = true,

--- a/manifests/pivot.pp
+++ b/manifests/pivot.pp
@@ -8,6 +8,7 @@
 #
 
 class druid::pivot (
+  $home_dir                     = '/opt/imply/dist/imply-ui',
   $config_dir                   = '/opt/imply/conf/pivot',
   $port                         = 9095,
   $broker_host                  = 'localhost:8082',

--- a/templates/pivot.init.erb
+++ b/templates/pivot.init.erb
@@ -11,6 +11,7 @@
 
 PIVOT_HOME="<%= scope.lookupvar("druid::pivot::home_dir") %>"
 PIVOT_CONFIG="<%= scope.lookupvar("druid::pivot::config_dir") %>/config.yaml"
+PIVOT_STATE="<%= scope.lookupvar("druid::pivot::state_file") %>"
 
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 DAEMON=/usr/bin/node
@@ -22,6 +23,7 @@ LOGFILE="<%= scope.lookupvar("druid::pivot::log_dir") %>/${NAME}.out"
 
 mkdir -p `dirname $PIDFILE`
 mkdir -p `dirname $LOGFILE`
+mkdir -p `dirname $PIVOT_STATE`
 
 . /lib/lsb/init-functions
 

--- a/templates/pivot.init.erb
+++ b/templates/pivot.init.erb
@@ -9,7 +9,7 @@
 # Description:       Druid pivot Node
 ### END INIT INFO
 
-PIVOT_HOME="/opt/imply/dist/pivot"
+PIVOT_HOME="<%= scope.lookupvar("druid::pivot::home_dir") %>"
 PIVOT_CONFIG="<%= scope.lookupvar("druid::pivot::config_dir") %>/config.yaml"
 
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin

--- a/templates/pivot_config.yaml.erb
+++ b/templates/pivot_config.yaml.erb
@@ -31,3 +31,11 @@ sourceListRefreshInterval: <%= scope.lookupvar("druid::pivot::source_list_refres
 # Foreground introspection
 # Checks for new dataSources every time Pivot is loaded (default: false)
 sourceListRefreshOnLoad: <%= scope.lookupvar("druid::pivot::source_list_refresh_onload") %>
+
+# The location, format and other options of the state store.
+# type: (mysql, pg, sqlite)
+# connection: connection string or filename in the case of sqlite
+# tablePrefix: optional, prefix for state table name
+stateStore:
+    type: 'sqlite'
+    connection: '<%= scope.lookupvar("druid::pivot::state_file") %>'


### PR DESCRIPTION
updated puppet druid module for imply-2.4.1
druid::pivot::home_dir to specify home directory for installation (moved in newest release)
druid::pivot:state_file to specify location of sqlite state
templates/pivot_config.yaml.erb to specify new configuration option stateStore