### PR TITLE
Feature/imply2.4.1 upgrade

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -347,9 +347,21 @@ This class will deployed and configure pivot.
 
 **Parameters within druid::pivot`:**
 
+#### `home_dir`
+
+String setting the home directory for the imply-ui distribution
+
+Default: `/opt/imply/dist/imply-ui`
+
 ##### `config_dir`
 
-Hash defining the configuration of the Druid Node
+String setting the configuration directory of the imply-ui distribution 
+
+Default: `/opt/imply/conf/pivot`
+
+#### `state_store`
+
+Hash defining the configuration of the state storage options for the imply-ui
 
 Default: `{}`
 

--- a/manifests/pivot.pp
+++ b/manifests/pivot.pp
@@ -10,7 +10,7 @@
 class druid::pivot (
   $home_dir                     = '/opt/imply/dist/imply-ui',
   $config_dir                   = '/opt/imply/conf/pivot',
-  $state_connection_string      = '',
+  $state_store                  = {},
   $port                         = 9095,
   $broker_host                  = 'localhost:8082',
   $enable_stdout_log            = true,

--- a/manifests/pivot.pp
+++ b/manifests/pivot.pp
@@ -10,7 +10,7 @@
 class druid::pivot (
   $home_dir                     = '/opt/imply/dist/imply-ui',
   $config_dir                   = '/opt/imply/conf/pivot',
-  $state_file                   = '/mnt/pivot/state',
+  $state_connection_string      = '',
   $port                         = 9095,
   $broker_host                  = 'localhost:8082',
   $enable_stdout_log            = true,

--- a/manifests/pivot.pp
+++ b/manifests/pivot.pp
@@ -10,6 +10,7 @@
 class druid::pivot (
   $home_dir                     = '/opt/imply/dist/imply-ui',
   $config_dir                   = '/opt/imply/conf/pivot',
+  $state_file                   = '/mnt/pivot/state',
   $port                         = 9095,
   $broker_host                  = 'localhost:8082',
   $enable_stdout_log            = true,

--- a/manifests/pivot.pp
+++ b/manifests/pivot.pp
@@ -8,6 +8,7 @@
 #
 
 class druid::pivot (
+  $home_dir                     = '/opt/imply/dist/imply-ui',
   $config_dir                   = '/opt/imply/conf/pivot',
   $port                         = 9095,
   $broker_host                  = 'localhost:8082',

--- a/templates/pivot.init.erb
+++ b/templates/pivot.init.erb
@@ -11,6 +11,7 @@
 
 PIVOT_HOME="<%= scope.lookupvar("druid::pivot::home_dir") %>"
 PIVOT_CONFIG="<%= scope.lookupvar("druid::pivot::config_dir") %>/config.yaml"
+PIVOT_STATE="<%= scope.lookupvar("druid::pivot::state_file") %>"
 
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 DAEMON=/usr/bin/node
@@ -22,6 +23,7 @@ LOGFILE="<%= scope.lookupvar("druid::pivot::log_dir") %>/${NAME}.out"
 
 mkdir -p `dirname $PIDFILE`
 mkdir -p `dirname $LOGFILE`
+mkdir -p `dirname $PIVOT_STATE`
 
 . /lib/lsb/init-functions
 

--- a/templates/pivot.init.erb
+++ b/templates/pivot.init.erb
@@ -11,7 +11,6 @@
 
 PIVOT_HOME="<%= scope.lookupvar("druid::pivot::home_dir") %>"
 PIVOT_CONFIG="<%= scope.lookupvar("druid::pivot::config_dir") %>/config.yaml"
-PIVOT_STATE="<%= scope.lookupvar("druid::pivot::state_file") %>"
 
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 DAEMON=/usr/bin/node
@@ -23,7 +22,6 @@ LOGFILE="<%= scope.lookupvar("druid::pivot::log_dir") %>/${NAME}.out"
 
 mkdir -p `dirname $PIDFILE`
 mkdir -p `dirname $LOGFILE`
-mkdir -p `dirname $PIVOT_STATE`
 
 . /lib/lsb/init-functions
 

--- a/templates/pivot.init.erb
+++ b/templates/pivot.init.erb
@@ -9,7 +9,7 @@
 # Description:       Druid pivot Node
 ### END INIT INFO
 
-PIVOT_HOME="/opt/imply/dist/pivot"
+PIVOT_HOME="<%= scope.lookupvar("druid::pivot::home_dir") %>"
 PIVOT_CONFIG="<%= scope.lookupvar("druid::pivot::config_dir") %>/config.yaml"
 
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin

--- a/templates/pivot_config.yaml.erb
+++ b/templates/pivot_config.yaml.erb
@@ -37,5 +37,5 @@ sourceListRefreshOnLoad: <%= scope.lookupvar("druid::pivot::source_list_refresh_
 # connection: connection string or filename in the case of sqlite
 # tablePrefix: optional, prefix for state table name
 stateStore:
-    type: 'mysql'
-    connection: '<%= scope.lookupvar("druid::pivot::state_connection_string") %>'
+    type: '<%= scope.lookupvar("druid::pivot::state_store")['type'] %>'
+    connection: '<%= scope.lookupvar("druid::pivot::state_store")['connection'] %>'

--- a/templates/pivot_config.yaml.erb
+++ b/templates/pivot_config.yaml.erb
@@ -37,5 +37,5 @@ sourceListRefreshOnLoad: <%= scope.lookupvar("druid::pivot::source_list_refresh_
 # connection: connection string or filename in the case of sqlite
 # tablePrefix: optional, prefix for state table name
 stateStore:
-    type: 'sqlite'
-    connection: '<%= scope.lookupvar("druid::pivot::state_file") %>'
+    type: 'mysql'
+    connection: '<%= scope.lookupvar("druid::pivot::state_connection_string") %>'

--- a/templates/pivot_config.yaml.erb
+++ b/templates/pivot_config.yaml.erb
@@ -31,3 +31,11 @@ sourceListRefreshInterval: <%= scope.lookupvar("druid::pivot::source_list_refres
 # Foreground introspection
 # Checks for new dataSources every time Pivot is loaded (default: false)
 sourceListRefreshOnLoad: <%= scope.lookupvar("druid::pivot::source_list_refresh_onload") %>
+
+# The location, format and other options of the state store.
+# type: (mysql, pg, sqlite)
+# connection: connection string or filename in the case of sqlite
+# tablePrefix: optional, prefix for state table name
+stateStore:
+    type: 'sqlite'
+    connection: '<%= scope.lookupvar("druid::pivot::state_file") %>'


### PR DESCRIPTION
- new variable in pivot manifest to allow configuration of home directory (helpful for backwards compatibility)
- new variable in pivot manifest `stateStore`, expected values "type" & "connection", allow configuration of stateStore database
- added stateStore to pivot/config.yaml which references new hash in druid::pivot class